### PR TITLE
Sorting issue

### DIFF
--- a/lib/plist/generator.rb
+++ b/lib/plist/generator.rb
@@ -78,7 +78,7 @@ module Plist::Emit
         else
           inner_tags = []
 
-          element.keys.sort.each do |k|
+          element.keys.sort_by{|k| k.to_s }.each do |k|
             v = element[k]
             inner_tags << tag('key', CGI::escapeHTML(k.to_s))
             inner_tags << plist_node(v)
@@ -210,13 +210,6 @@ module Plist::Emit
         @contents << "\n" unless val =~ /\n$/
       end
     end
-  end
-end
-
-# we need to add this so sorting hash keys works properly
-class Symbol #:nodoc:
-  def <=> (other)
-    self.to_s <=> other.to_s
   end
 end
 

--- a/test/test_generator.rb
+++ b/test/test_generator.rb
@@ -51,4 +51,25 @@ class TestGenerator < Test::Unit::TestCase
 
     File.unlink('test.plist')
   end
+
+  # The hash in this test was failing with 'hsh.keys.sort',
+  # we are making sure it works with 'hsh.keys.sort_by'.
+  def test_sorting_keys
+    hsh = {:key1 => 1, :key4 => 4, 'key2' => 2, :key3 => 3}
+    output = Plist::Emit.plist_node(hsh)
+    expected = <<-STR
+<dict>
+  <key>key1</key>
+  <integer>1</integer>
+  <key>key2</key>
+  <integer>2</integer>
+  <key>key3</key>
+  <integer>3</integer>
+  <key>key4</key>
+  <integer>4</integer>
+</dict>
+    STR
+
+    assert_equal expected, output.gsub(/[\t]/, "\s\s")
+  end
 end


### PR DESCRIPTION
As discussed, here's the change of sort to sort_by to allow hashes with both symbols and strings as keys to work.
