### PR TITLE
Allow default indentation to be configured

### DIFF
--- a/lib/plist.rb
+++ b/lib/plist.rb
@@ -18,4 +18,5 @@ require 'plist/parser'
 
 module Plist
   VERSION = '3.1.0'
+  SETTINGS = { :indent => "\t" }
 end

--- a/lib/plist/generator.rb
+++ b/lib/plist/generator.rb
@@ -173,7 +173,7 @@ module Plist::Emit
   class IndentedString #:nodoc:
     attr_accessor :indent_string
 
-    def initialize(str = "\t")
+    def initialize(str = Plist::SETTINGS[:indent])
       @indent_string = str
       @contents = ''
       @indent_level = 0

--- a/test/test_generator_collections.rb
+++ b/test/test_generator_collections.rb
@@ -74,4 +74,25 @@ END
 
     assert_equal expected, [{:foo => 'bar'}, :b, 3].to_plist(false)
   end
+
+  def test_collection_without_indentation
+    original_indent = Plist::SETTINGS[:indent]
+    begin
+      Plist::SETTINGS[:indent] = nil
+      expected = <<END
+<array>
+<dict>
+<key>foo</key>
+<string>bar</string>
+</dict>
+<string>b</string>
+<integer>3</integer>
+</array>
+END
+
+      assert_equal expected, [{:foo => 'bar'}, :b, 3].to_plist(false)
+    ensure
+      Plist::SETTINGS[:indent] = original_indent
+    end
+  end
 end


### PR DESCRIPTION
This commit enables the default indentation method to be chosen by the developer, instead of being hard coded to a tab. An associated test is included.
