### PR TITLE
options to control keysorting when dumping

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,10 +10,9 @@
 
 require 'fileutils'
 require 'rubygems'
+require 'rubygems/package_task'
 require 'rake'
 require 'rake/testtask'
-require 'rake/packagetask'
-require 'rake/gempackagetask'
 require 'rake/contrib/rubyforgepublisher'
 
 $:.unshift(File.dirname(__FILE__) + "/lib")
@@ -146,7 +145,7 @@ EOD
   s.autorequire = 'plist'
 end
 
-Rake::GemPackageTask.new(spec) do |p|
+Gem::PackageTask.new(spec) do |p|
   p.gem_spec = spec
   p.need_tar = true
   p.need_zip = true

--- a/test/test_generator.rb
+++ b/test/test_generator.rb
@@ -52,11 +52,14 @@ class TestGenerator < Test::Unit::TestCase
     File.unlink('test.plist')
   end
 
+  def spaces_to_tabs(s)
+    return s.gsub("\s\s", "\t")
+  end
+
   # The hash in this test was failing with 'hsh.keys.sort',
   # we are making sure it works with 'hsh.keys.sort_by'.
   def test_sorting_keys
     hsh = {:key1 => 1, :key4 => 4, 'key2' => 2, :key3 => 3}
-    output = Plist::Emit.plist_node(hsh)
     expected = <<-STR
 <dict>
   <key>key1</key>
@@ -69,7 +72,39 @@ class TestGenerator < Test::Unit::TestCase
   <integer>4</integer>
 </dict>
     STR
+    expected = spaces_to_tabs(expected)
+    assert_equal expected, Plist::Emit.dump(hsh, false)
+  end
 
-    assert_equal expected, output.gsub(/[\t]/, "\s\s")
+  def test_hash_is_sorted
+    expected = <<END
+<dict>
+  <key>a</key>
+  <string>a</string>
+  <key>b</key>
+  <string>b</string>
+</dict>
+END
+    h = Hash.new
+    h['b'] = 'b'
+    h['a'] = 'a'
+    expected = spaces_to_tabs(expected)
+    assert_equal expected, Plist::Emit.dump(h, false)
+  end
+
+  def test_hash_keeps_order_when_desired
+    expected = <<END
+<dict>
+  <key>b</key>
+  <string>b</string>
+  <key>a</key>
+  <string>a</string>
+</dict>
+END
+    h = Hash.new
+    h['b'] = 'b'
+    h['a'] = 'a'
+    expected = spaces_to_tabs(expected)
+    assert_equal expected, Plist::Emit.dump(h, false, :sort => false)
   end
 end


### PR DESCRIPTION
hi ... would you consider including this patch to control the sorting of keys when exporting back to plists-xml format? i wanted to manipulate an existing plist file for another program which uses the order of the dicts (even so it should not depend on a particular order). the patching of the plist is perfect with your library, but the export killed the other program
