### PR TITLE
added a note comment about using to_plist method

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -71,6 +71,8 @@ If you've mixed in <tt>Plist::Emit</tt> (which is already done for +Array+ and +
 
   obj.to_plist
 
+NOTE: The .to_plist method will make the Ruby plist hash into a string. It will not automatically re-write an original plist. You need to use a string writing gem or method something similar to Pathname gem's write method or anything useful. 
+
 This is equivalent to calling <tt>Plist::Emit.dump(obj)</tt>.  Either one will yield:
 
   <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
I added a note comment in the README.rdoc file. I hope this could help clarify the usage of the `.to_plist` method of this gem as how I saw it in my usage. If by any chance there is a method that does something like re-writing the values of a `plist` file that was parsed with the `parse_xml` method, please point me to it and then you could ignore this PR. Thanks!
