### PR TITLE
Multiline string values must not be indented

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: ruby
+rvm:
+  - 1.9.3
+  - 1.9.2
+  - jruby-18mode
+  - jruby-19mode
+  - rbx-18mode
+  - rbx-19mode
+  - ruby-head
+  - jruby-head
+  - 1.8.7
+  - ree

--- a/README.rdoc
+++ b/README.rdoc
@@ -20,7 +20,7 @@ Plist is a library to manipulate Property List files, also known as plists.  It 
 ==== Example Property List
 
   <?xml version="1.0" encoding="UTF-8"?>
-  <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+  <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
   <plist version="1.0">
   <dict>
           <key>FirstName</key>
@@ -74,7 +74,7 @@ If you've mixed in <tt>Plist::Emit</tt> (which is already done for +Array+ and +
 This is equivalent to calling <tt>Plist::Emit.dump(obj)</tt>.  Either one will yield:
 
   <?xml version="1.0" encoding="UTF-8"?>
-  <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+  <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
   <plist version="1.0">
   <array>
       <integer>1</integer>

--- a/README.rdoc
+++ b/README.rdoc
@@ -1,5 +1,7 @@
 = All-purpose Property List manipulation library
 
+= Note: This is an updated version of the original plist gem. It supports multiline string values.
+
 Plist is a library to manipulate Property List files, also known as plists.  It can parse plist files into native Ruby data structures as well as generating new plist files from your Ruby objects.
 
 == Info

--- a/README.rdoc
+++ b/README.rdoc
@@ -2,7 +2,14 @@
 
 Plist is a library to manipulate Property List files, also known as plists.  It can parse plist files into native Ruby data structures as well as generating new plist files from your Ruby objects.
 
+== Info
+
+  This version of the plist gem fixes the additional whitespace in front of every line of multiline text values.
+
 == Usage
+
+=== Install
+    gem install plist.newline
 
 === Parsing
 
@@ -155,4 +162,3 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-

--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,6 @@ require 'rake/testtask'
 require 'rake/packagetask'
 require 'rake/gempackagetask'
 require 'rake/contrib/rubyforgepublisher'
-require 'rdoc/task'
 
 $:.unshift(File.dirname(__FILE__) + "/lib")
 require 'plist'
@@ -103,19 +102,25 @@ task :update_rdoc => [ :rdoc ] do
   Rake::SshDirPublisher.new("#{RUBYFORGE_USER}@rubyforge.org", "/var/www/gforge-projects/#{RUBYFORGE_PROJECT}", "rdoc").upload
 end
 
-# Genereate the RDoc documentation
-RDoc::Task.new do |rdoc|
-  rdoc.title = "All-purpose Property List manipulation library"
-  rdoc.main  = "README.rdoc"
+begin
+  require 'rdoc/task'
 
-  rdoc.rdoc_dir = 'rdoc'
-  rdoc.rdoc_files.include('README.rdoc', 'LICENSE', 'CHANGELOG')
-  rdoc.rdoc_files.include('lib/**')
-
-  rdoc.options = [
-    '-H', # show hash marks on method names in comments
-    '-N', # show line numbers
-  ]
+  # Generate the RDoc documentation
+  RDoc::Task.new do |rdoc|
+    rdoc.title = "All-purpose Property List manipulation library"
+    rdoc.main  = "README.rdoc"
+    
+    rdoc.rdoc_dir = 'rdoc'
+    rdoc.rdoc_files.include('README.rdoc', 'LICENSE', 'CHANGELOG')
+    rdoc.rdoc_files.include('lib/**')
+    
+    rdoc.options = [
+      '-H', # show hash marks on method names in comments
+      '-N', # show line numbers
+    ]
+  end
+rescue LoadError
+  $stderr.puts "Could not load rdoc tasks"
 end
 
 # Create compressed packages

--- a/Rakefile
+++ b/Rakefile
@@ -13,8 +13,8 @@ require 'rubygems'
 require 'rake'
 require 'rake/testtask'
 require 'rake/packagetask'
-require 'rake/gempackagetask'
 require 'rake/contrib/rubyforgepublisher'
+require 'rubygems/package_task'
 
 $:.unshift(File.dirname(__FILE__) + "/lib")
 require 'plist'
@@ -146,8 +146,9 @@ EOD
   s.autorequire = 'plist'
 end
 
-Rake::GemPackageTask.new(spec) do |p|
+Gem::PackageTask.new(spec) do |p|
   p.gem_spec = spec
   p.need_tar = true
   p.need_zip = true
 end
+

--- a/Rakefile
+++ b/Rakefile
@@ -38,7 +38,7 @@ task :default => [ :test ]
 # Run the unit tests
 Rake::TestTask.new { |t|
   t.libs << "test"
-  t.pattern = 'test/test_*.rb'
+  t.test_files = TEST_FILES
   t.verbose = true
 }
 

--- a/Rakefile
+++ b/Rakefile
@@ -109,11 +109,11 @@ begin
   RDoc::Task.new do |rdoc|
     rdoc.title = "All-purpose Property List manipulation library"
     rdoc.main  = "README.rdoc"
-    
+
     rdoc.rdoc_dir = 'rdoc'
     rdoc.rdoc_files.include('README.rdoc', 'LICENSE', 'CHANGELOG')
     rdoc.rdoc_files.include('lib/**')
-    
+
     rdoc.options = [
       '-H', # show hash marks on method names in comments
       '-N', # show line numbers

--- a/lib/plist.rb
+++ b/lib/plist.rb
@@ -17,5 +17,5 @@ require 'plist/generator'
 require 'plist/parser'
 
 module Plist
-  VERSION = '3.2.0'
+  VERSION = '3.2.2'
 end

--- a/lib/plist.rb
+++ b/lib/plist.rb
@@ -17,5 +17,5 @@ require 'plist/generator'
 require 'plist/parser'
 
 module Plist
-  VERSION = '3.1.0'
+  VERSION = '3.2.0'
 end

--- a/lib/plist/generator.rb
+++ b/lib/plist/generator.rb
@@ -125,13 +125,11 @@ module Plist::Emit
     out = nil
 
     if block_given?
-      out = IndentedString.new
+      out = RecursiveString.new
       out << "<#{type}>"
-      out.raise_indent
 
       out << block.call
 
-      out.lower_indent
       out << "</#{type}>"
     else
       out = "<#{type}>#{contents.to_s}</#{type}>\n"
@@ -169,26 +167,17 @@ module Plist::Emit
       raise "Don't know about this data type... something must be wrong!"
     end
   end
-  private
-  class IndentedString #:nodoc:
+
+  class RecursiveString #:nodoc:
     attr_accessor :indent_string
 
     def initialize(str = "\t")
       @indent_string = str
       @contents = ''
-      @indent_level = 0
     end
 
     def to_s
-      return @contents
-    end
-
-    def raise_indent
-      @indent_level += 1
-    end
-
-    def lower_indent
-      @indent_level -= 1 if @indent_level > 0
+      @contents
     end
 
     def <<(val)
@@ -197,17 +186,7 @@ module Plist::Emit
           self << f
         end
       else
-        # if it's already indented, don't bother indenting further
-        unless val =~ /\A#{@indent_string}/
-          indent = @indent_string * @indent_level
-
-          @contents << val.gsub(/^/, indent)
-        else
-          @contents << val
-        end
-
-        # it already has a newline, don't add another
-        @contents << "\n" unless val =~ /\n$/
+        @contents << val
       end
     end
   end

--- a/lib/plist/generator.rb
+++ b/lib/plist/generator.rb
@@ -78,7 +78,7 @@ module Plist::Emit
         else
           inner_tags = []
 
-          element.keys.sort.each do |k|
+          element.keys.sort_by{|k| k.to_s }.each do |k|
             v = element[k]
             inner_tags << tag('key', CGI::escapeHTML(k.to_s))
             inner_tags << plist_node(v)
@@ -210,13 +210,6 @@ module Plist::Emit
         @contents << "\n" unless val =~ /\n$/
       end
     end
-  end
-end
-
-# we need to add this so sorting hash keys works properly
-class Symbol #:nodoc:
-  def <=> (other)
-    self.to_s <=> other.to_s
   end
 end
 

--- a/lib/plist/generator.rb
+++ b/lib/plist/generator.rb
@@ -144,7 +144,7 @@ module Plist::Emit
     output = ''
 
     output << '<?xml version="1.0" encoding="UTF-8"?>' + "\n"
-    output << '<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">' + "\n"
+    output << '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">' + "\n"
     output << '<plist version="1.0">' + "\n"
 
     output << contents

--- a/lib/plist/parser.rb
+++ b/lib/plist/parser.rb
@@ -63,7 +63,7 @@ module Plist
     def initialize( plist_data_or_file, listener )
       if plist_data_or_file.respond_to? :read
         @xml = plist_data_or_file.read
-      elsif File.exists? plist_data_or_file
+      elsif File.exist? plist_data_or_file
         @xml = File.read( plist_data_or_file )
       else
         @xml = plist_data_or_file

--- a/lib/plist/parser.rb
+++ b/lib/plist/parser.rb
@@ -210,8 +210,7 @@ module Plist
   require 'base64'
   class PData < PTag
     def to_ruby
-      data = Base64.decode64(text.gsub(/\s+/, ''))
-
+      data = Base64.decode64(text.gsub(/\s+/, '')) unless text.nil?
       begin
         return Marshal.load(data)
       rescue Exception => e

--- a/plist.gemspec
+++ b/plist.gemspec
@@ -1,0 +1,20 @@
+# coding: utf-8
+
+Gem::Specification.new do |spec|
+  spec.name          = "plist.newline"
+  spec.version       = '3.2.2'
+  spec.authors       = ["bkoell"]
+  spec.email         = ["bastian.koell@gmail.com"]
+  spec.summary       = "plist.newline is an updated version of the plist gem that supports multiline string values"
+  spec.description   = "plist.newline is an updated version of the plist gem that supports multiline string values"
+  spec.homepage      = ""
+  spec.license       = "MIT"
+
+  spec.files         = `git ls-files -z`.split("\x0")
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.require_paths = ["lib"]
+
+  spec.add_development_dependency "bundler", "~> 1.5"
+  spec.add_development_dependency "rake"
+end

--- a/test/assets/AlbumData.xml
+++ b/test/assets/AlbumData.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>Application Version</key>

--- a/test/assets/Cookies.plist
+++ b/test/assets/Cookies.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <array>
 	<dict>

--- a/test/assets/commented.plist
+++ b/test/assets/commented.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <!-- I am a comment! -->
 <!--

--- a/test/assets/example_data.plist
+++ b/test/assets/example_data.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>IMs</key>

--- a/test/assets/test_data_elements.plist
+++ b/test/assets/test_data_elements.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
     <key>stringio</key>

--- a/test/assets/test_data_elements.plist
+++ b/test/assets/test_data_elements.plist
@@ -20,5 +20,7 @@
     <data>BAhvOhZNYXJzaGFsYWJsZU9iamVjdAY6CUBmb28iHnRoaXMgb2JqZWN0IHdh
     cyBtYXJzaGFsZWQ=
     </data>
+    <key>nodata</key>
+    <data/>
   </dict>
 </plist>

--- a/test/assets/test_empty_key.plist
+++ b/test/assets/test_empty_key.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
     <key>key</key>

--- a/test/test_generator.rb
+++ b/test/test_generator.rb
@@ -51,4 +51,25 @@ class TestGenerator < Test::Unit::TestCase
 
     File.unlink('test.plist')
   end
+
+  # The hash in this test was failing with 'hsh.keys.sort',
+  # we are making sure it works with 'hsh.keys.sort_by'.
+  def test_sorting_keys
+    hsh = {:key1 => 1, :key4 => 4, 'key2' => 2, :key3 => 3}
+    output = Plist::Emit.plist_node(hsh)
+    expected = <<-STR
+<dict>
+  <key>key1</key>
+  <integer>1</integer>
+  <key>key2</key>
+  <integer>2</integer>
+  <key>key3</key>
+  <integer>3</integer>
+  <key>key4</key>
+  <integer>4</integer>
+</dict>
+    STR
+
+    assert_equal expected, output.gsub(/[\t]/, "\s\s")
+  end
 end


### PR DESCRIPTION
Hey everyone,
multiline plist values get modified even when you don't do any changes. Multiline strings are expected to be not indented or the indentation will be part of the string that is read later on. You can easily see this behaviour creating Plists with Xcode for example.

I ran into this especially because we are using multiline markdown values which then render incorrectly because of indentation changes. 

Would very much appreciate if this could make its way into the gem. Don't want to deploy a custom one all the time. 

Thanks from Berlin!