### PR TITLE
Fix unused variable `e` warning

### DIFF
--- a/lib/plist/parser.rb
+++ b/lib/plist/parser.rb
@@ -213,7 +213,7 @@ module Plist
       data = Base64.decode64(text.gsub(/\s+/, '')) unless text.nil?
       begin
         return Marshal.load(data)
-      rescue Exception => e
+      rescue Exception
         io = StringIO.new
         io.write data
         io.rewind


### PR DESCRIPTION
When the plist gem is used with Ruby warnings enabled (as is the default for newer versions of Rake), the following warning was printed:

```
plist/parser.rb:216: warning: assigned but unused variable - e
```

This PR removes the unused variable to fix this warning.