### PR TITLE
Fix Fixnum, Bignum deprecations in Ruby 2.4

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -5,6 +5,7 @@
 https://github.com/patsplat/plist/compare/dece870...HEAD
 
 * Your contribution here!
+* Fix Fixnum, Bignum deprecations in Ruby 2.4
 
 === 3.2.0 (2016-01-28)
 

--- a/lib/plist/generator.rb
+++ b/lib/plist/generator.rb
@@ -94,7 +94,7 @@ module Plist::Emit
         output << tag('date', element.utc.strftime('%Y-%m-%dT%H:%M:%SZ'))
       when Date # also catches DateTime
         output << tag('date', element.strftime('%Y-%m-%dT%H:%M:%SZ'))
-      when String, Symbol, Fixnum, Bignum, Integer, Float
+      when String, Symbol, Integer, Float
         output << tag(element_type(element), CGI::escapeHTML(element.to_s))
       when IO, StringIO
         element.rewind
@@ -159,7 +159,7 @@ module Plist::Emit
     when String, Symbol
       'string'
 
-    when Fixnum, Bignum, Integer
+    when Integer
       'integer'
 
     when Float


### PR DESCRIPTION
Fixnum and Bignum have been deprecated in Ruby 2.4. In any case, both of these classes are subclasses of Integer, so using just Integer in the case statements is sufficient. This PR removes references to Fixnum and Bignum to silence these warnings:

```
plist/generator.rb:97: warning: constant ::Fixnum is deprecated
plist/generator.rb:97: warning: constant ::Bignum is deprecated
plist/generator.rb:162: warning: constant ::Fixnum is deprecated
plist/generator.rb:162: warning: constant ::Bignum is deprecated
```