### PR TITLE
Remove rbx from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ rvm:
   - 1.9.2
   - jruby-18mode
   - jruby-19mode
-  - rbx-18mode
-  - rbx-19mode
   - ruby-head
   - jruby-head
   - 1.8.7


### PR DESCRIPTION
rvm no longer hosts binaries for rbx-d18 and rbx-d19, so remove these from our Travis matrix.