### PR TITLE
Fix ASCII/UTF-8 error.

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -5,6 +5,7 @@
 https://github.com/patsplat/plist/compare/dece870...HEAD
 
 * Your contribution here!
+* Fix ASCII/UTF-8 error (https://github.com/patsplat/plist/pull/38).
 * Fix Fixnum, Bignum deprecations in Ruby 2.4
 * Fix unused variable `e` warning
 

--- a/test/assets/non-ascii-but-utf-8.plist
+++ b/test/assets/non-ascii-but-utf-8.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>non-ascii-but-utf8-character</key>
+	<string></string>
+</dict>
+</plist>

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -90,6 +90,12 @@ class TestParser < Test::Unit::TestCase
     assert_nil data
   end
 
-end
+  def test_filename_or_xml_is_encoded_with_ascii_8bit
+    xml = File.open("test/assets/non-ascii-but-utf-8.plist", "r:ASCII-8BIT", &:read)
 
-__END__
+    assert_nothing_raised do
+      data = Plist::parse_xml(xml)
+      assert_equal("\u0099", data["non-ascii-but-utf8-character"])
+    end
+  end
+end

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -91,7 +91,11 @@ class TestParser < Test::Unit::TestCase
   end
 
   def test_filename_or_xml_is_encoded_with_ascii_8bit
-    xml = File.open("test/assets/non-ascii-but-utf-8.plist", "r:ASCII-8BIT", &:read)
+    # skip if Ruby version does not support String#force_encoding
+    return unless String.method_defined?(:force_encoding)
+
+    xml = File.read("test/assets/non-ascii-but-utf-8.plist")
+    xml.force_encoding("ASCII-8BIT")
 
     assert_nothing_raised do
       data = Plist::parse_xml(xml)


### PR DESCRIPTION
Fixes https://github.com/patsplat/plist/issues/21.

This will change the encoding according to the `<?xml encoding="..."?>` tag, and only if the specified encoding is supported by Ruby's `Encoding` class.