### PR TITLE
Improve plist generator: fix string serialization, speedup, and support more options...

### DIFF
--- a/lib/plist/generator.rb
+++ b/lib/plist/generator.rb
@@ -33,7 +33,14 @@ module Plist
 
     def generate element
       if element.respond_to? :to_plist_node
-        @output << element.to_plist_node
+        plist_node = element.to_plist_node
+        if !plist_node.start_with?(@indent)
+          plist_node = @indent + plist_node
+        end
+        if !plist_node.end_with?("\n")
+          plist_node = plist_node + "\n"
+        end
+        @output << plist_node
         return
       end
 

--- a/test/test_generate_and_parse.rb
+++ b/test/test_generate_and_parse.rb
@@ -1,0 +1,21 @@
+require 'test/unit'
+require 'plist'
+
+class TestGenerateAndParse < Test::Unit::TestCase
+  def test_generate_and_parse
+    t = Time.now
+    date = Date.new(t.year, t.month, t.day)
+    hash = {
+      "a key with \n new line inside" => "a value with \n new line inside",
+      "foo" => [
+        1.0,
+        2,
+        true,
+        false,
+        date
+      ]
+    }
+    new_hash = Plist.parse_xml Plist::Emit.dump hash
+    assert_equal hash, new_hash
+  end
+end

--- a/test/test_generator.rb
+++ b/test/test_generator.rb
@@ -36,7 +36,19 @@ class TestGenerator < Test::Unit::TestCase
     str = 'this object implements #to_plist_node'
     so = SerializableObject.new(str)
 
-    assert_equal "<string>#{str}</string>", Plist::Emit.dump(so, false)
+    assert_equal "<string>#{str}</string>\n", Plist::Emit.dump(so, false)
+  end
+
+  def test_dumping_serializable_object_with_indent
+    str = 'this object implements #to_plist_node'
+    so = SerializableObject.new(str)
+    expected = <<-END
+<array>
+	<string>#{str}</string>
+</array>
+END
+
+    assert_equal expected, Plist::Emit.dump([so], false)
   end
 
   def test_write_plist

--- a/test/test_generator.rb
+++ b/test/test_generator.rb
@@ -54,7 +54,7 @@ class TestGenerator < Test::Unit::TestCase
   # we are making sure it works with 'hsh.keys.sort_by'.
   def test_sorting_keys
     hsh = {:key1 => 1, :key4 => 4, 'key2' => 2, :key3 => 3}
-    output = Plist::Emit.plist_node(hsh)
+    output = Plist::Emit.dump(hsh, false)
     expected = <<-STR
 <dict>
   <key>key1</key>
@@ -71,14 +71,97 @@ class TestGenerator < Test::Unit::TestCase
     assert_equal expected, output.gsub(/[\t]/, "\s\s")
   end
 
+  def test_custom_base64_format
+    hash = {:key1 => StringIO.new('f' * 41)}
+    actual = Plist::Emit.dump(hash, false, :base64_width => 16, :base64_indent => false)
+    expected = <<-STR
+<dict>
+	<key>key1</key>
+	<data>
+ZmZmZmZmZmZmZmZm
+ZmZmZmZmZmZmZmZm
+ZmZmZmZmZmZmZmZm
+ZmZmZmY=
+	</data>
+</dict>
+STR
+    assert_equal expected, actual
+
+    actual = Plist::Emit.dump(hash, false, :base64_width => 12, :base64_indent => false)
+    expected = <<-STR
+<dict>
+	<key>key1</key>
+	<data>
+ZmZmZmZmZmZm
+ZmZmZmZmZmZm
+ZmZmZmZmZmZm
+ZmZmZmZmZmZm
+ZmZmZmY=
+	</data>
+</dict>
+STR
+    assert_equal expected, actual
+
+    assert_raises ArgumentError do
+      Plist::Emit.dump(hash, false, :base64_width => 17, :base64_indent => true)
+    end
+  end
+
   def test_custom_indent
+    hash = { :key1 => 1, 'key2' => [3] }
+
+    actual = Plist::Emit.dump(hash, true, :indent => '   ')
+    expected = <<-STR
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+   <key>key1</key>
+   <integer>1</integer>
+   <key>key2</key>
+   <array>
+      <integer>3</integer>
+   </array>
+</dict>
+</plist>
+STR
+    assert_equal expected, actual
+
+    actual = Plist::Emit.dump(hash, false, :indent => '   ', :initial_indent => "\t")
+    expected = <<-STR
+	<dict>
+	   <key>key1</key>
+	   <integer>1</integer>
+	   <key>key2</key>
+	   <array>
+	      <integer>3</integer>
+	   </array>
+	</dict>
+STR
+    assert_equal expected, actual
+  end
+
+  def test_envelope
     hsh = { :key1 => 1, 'key2' => 2 }
-    output_plist_node = Plist::Emit.plist_node(hsh, :indent =>  nil)
     output_plist_dump_with_envelope = Plist::Emit.dump(hsh, true, :indent => nil)
+    output_plist_dump_with_xml11_envelope = Plist::Emit.dump(hsh, true, :indent => nil, :xml_version => '1.1')
     output_plist_dump_no_envelope = Plist::Emit.dump(hsh, false, :indent => nil)
 
     expected_with_envelope = <<-STR
 <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+<key>key1</key>
+<integer>1</integer>
+<key>key2</key>
+<integer>2</integer>
+</dict>
+</plist>
+STR
+
+    expected_with_xml11_envelope = <<-STR
+<?xml version="1.1" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -98,8 +181,8 @@ STR
 <integer>2</integer>
 </dict>
 STR
-    assert_equal expected_no_envelope, output_plist_node
     assert_equal expected_with_envelope, output_plist_dump_with_envelope
+    assert_equal expected_with_xml11_envelope, output_plist_dump_with_xml11_envelope
     assert_equal expected_no_envelope, output_plist_dump_no_envelope
 
     hsh.save_plist('test.plist', :indent => nil)

--- a/test/test_generator_basic_types.rb
+++ b/test/test_generator_basic_types.rb
@@ -31,6 +31,12 @@ class TestGeneratorBasicTypes < Test::Unit::TestCase
     end
   end
 
+  def test_floats_that_can_be_rounded
+    [0.0, 4.0].each do |i|
+      assert_equal wrap('real', i.to_i), Plist::Emit.dump(i, false).chomp
+    end
+  end
+
   def test_booleans
     assert_equal "<true/>",  Plist::Emit.dump(true, false).chomp
     assert_equal "<false/>", Plist::Emit.dump(false, false).chomp

--- a/test/test_generator_collections.rb
+++ b/test/test_generator_collections.rb
@@ -36,6 +36,17 @@ END
     assert_equal expected, {:foo => :bar, :abc => 123}.to_plist(false)
   end
 
+  def test_hash_with_newline_in_key
+    expected = <<END
+<dict>
+	<key>abc
+def</key>
+	<real>123</real>
+</dict>
+END
+    assert_equal expected, {"abc\ndef" => 123.0}.to_plist(false)
+  end
+
   def test_empty_hash
     expected = <<END
 <dict/>


### PR DESCRIPTION
The rewrite adds a `Generator` class to replace `IndentedString`, which handles indentation in a global level. This implementation is cleaner and faster:

- Improve dump speed, the original implementation concats string a lot, which will incur massive memory copying. The new implementation uses `Array#join` when many concats happens so the calls to `memcpy()` are greatly reduced.
- Reduce object allocation since `Generator` is only allocated once
- Simplify base64 data generating and speed it up

And this implementation also fixes compatibility issues with other plist tools:

- Fix `<key>` and `<string>` bug by incorrect indentation. Now it is safe to use `<key>` or `<string>` with new lines inside.
- Do not escape quotes because it is not required in XML element content (same behavior as PlistBuddy and libplist)

And this rewrite also adds more options for specifying different xml version and base64 encoded string width (so that I can generate exactly the same plist as generated by Apple's MZXMLMarshalling.framework):

- Support base64 data formatting options `:base64_width` and `:base64_indent`
- Support option `:initial_indent` when formating a segment of plist
- Can specify `:xml_version` when generating enveloped plist

---

The benchmark code:

```
require 'benchmark'
require 'plist'
require 'stringio'

bin_data = 'f' * 10000
array = 2000.times.map{ StringIO.new bin_data } + 2000.times.map { bin_data }

Benchmark.bm {
  puts Benchmark.measure {
    Plist::Emit.dump array
  }
}
```

Benchmark before:

```
       user     system      total        real
  2.010000   0.060000   2.070000 (  2.075573)
```

Benchmark after:

```
       user     system      total        real
  0.600000   0.030000   0.630000 (  0.634947)
```
