### PR TITLE
Only ship the required libs in the gem artifact

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,11 @@ rvm:
   - 1.9.3
   - 2.0.0-p648 # macOS
   - 2.1.10
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
+  - 2.2.10
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
+  - 2.6
   - ruby-head
   - jruby-head
 before_install: gem install bundler -v '~> 1.14' --conservative

--- a/plist.gemspec
+++ b/plist.gemspec
@@ -17,11 +17,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/patsplat/plist"
   spec.license       = "MIT"
 
-  spec.files = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
-  end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.files = %w{LICENSE.txt} + Dir.glob("lib/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.14"


### PR DESCRIPTION
This strips the test/development files from the gemspec so that the gem
artifact only includes the bare minimum required libraries. This reduces
the total install size for applications that bundle this gem.

Signed-off-by: Tim Smith <tsmith@chef.io>