### PR TITLE
Added option to decide whether hash keys should be sorted

### DIFF
--- a/lib/plist/generator.rb
+++ b/lib/plist/generator.rb
@@ -23,6 +23,7 @@ module Plist
   # For detailed usage instructions, refer to USAGE[link:files/docs/USAGE.html] and the methods documented below.
   module Emit
     DEFAULT_INDENT = "\t"
+    SORT_HASH_KEYS = true
 
     # Helper method for injecting into classes.  Calls <tt>Plist::Emit.dump</tt> with +self+.
     def to_plist(envelope = true, options = {})
@@ -45,7 +46,7 @@ module Plist
     #
     # The +envelope+ parameters dictates whether or not the resultant plist fragment is wrapped in the normal XML/plist header and footer.  Set it to false if you only want the fragment.
     def self.dump(obj, envelope = true, options = {})
-      options = { :indent => DEFAULT_INDENT }.merge(options)
+      options = { :indent => DEFAULT_INDENT, :sort_hash_keys => SORT_HASH_KEYS }.merge(options)
       output = plist_node(obj, options)
 
       output = wrap(output) if envelope
@@ -63,7 +64,7 @@ module Plist
 
     private
     def self.plist_node(element, options = {})
-      options = { :indent => DEFAULT_INDENT }.merge(options)
+      options = { :indent => DEFAULT_INDENT, :sort_hash_keys => SORT_HASH_KEYS }.merge(options)
       output = ''
 
       if element.respond_to? :to_plist_node
@@ -83,8 +84,13 @@ module Plist
             output << "<dict/>\n"
           else
             inner_tags = []
-
-            element.keys.sort_by{|k| k.to_s }.each do |k|
+            keys = []
+            if options[:sort_hash_keys]
+              keys = element.keys.sort_by{|k| k.to_s }
+            else
+              keys = element.keys
+            end
+            keys.each do |k|
               v = element[k]
               inner_tags << tag('key', CGI.escapeHTML(k.to_s), options)
               inner_tags << plist_node(v, options)

--- a/test/test_generator.rb
+++ b/test/test_generator.rb
@@ -107,4 +107,20 @@ STR
     assert_equal expected_with_envelope, output_plist_file
     File.unlink('test.plist')
   end
+
+  def test_no_sort_hash_keys
+    hsh = { :keyC => 'c', :keyA => 'a', :keyB => 'b' }
+    output_plist_dump_no_envelope = Plist::Emit.dump(hsh, false, {:indent => nil, :sort_hash_keys => false})
+    expected_no_envelope = <<-STR
+<dict>
+<key>keyC</key>
+<string>c</string>
+<key>keyA</key>
+<string>a</string>
+<key>keyB</key>
+<string>b</string>
+</dict>
+STR
+    assert_equal expected_no_envelope, output_plist_dump_no_envelope
+  end
 end


### PR DESCRIPTION
The hash keys are sorted which creates problems in use cases like simply editing and saving of existing plist, whose keys (in dictionaries) are not sorted but after saving the plist the whole file seems to me changed. This PR adds the option to not sort hash keys, by default it's `true` in order to be backward compatible with existing behaviour.