### PR TITLE
Update Travis CI config; fix double PR builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
-sudo: false
+---
 language: ruby
+cache: bundler
+branches:
+  only:
+    - master
 rvm:
   - jruby-18mode
   - jruby-19mode


### PR DESCRIPTION
- Travis no longer uses `sudo: false`; remove it.
- Fix an issue where PRs would get built by Travis twice: once for the PR, and once for the branch.
- Enable Bundler cache.