### PR TITLE
Allow `Marshal.load` to be disabled for `Plist.parse_xml`

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -9,12 +9,17 @@ Plist is a library to manipulate Property List files, also known as plists.  It 
 
 === Security considerations
 
-Plist.parse_xml uses Marshal.load for <data/> attributes. If the <data/> attribute contains malicious data, an attacker can gain code execution.
-You should never use Plist.parse_xml with untrusted plists!
+By default, Plist.parse_xml uses Marshal.load for <data/> attributes. If the <data/> attribute contains malicious data, an attacker can gain code execution.
+
+You should never use the default Plist.parse_xml with untrusted plists!
+
+To disable the Marshal.load behavior, use <tt>marshal: false</tt>. This will return the raw binary <data> contents as an IO object instead of attempting to unmarshal it.
 
 === Parsing
 
   result = Plist.parse_xml('path/to/example.plist')
+  # or
+  result = Plist.parse_xml('path/to/example.plist', marshal: false)
 
   result.class
   => Hash

--- a/lib/plist/parser.rb
+++ b/lib/plist/parser.rb
@@ -26,6 +26,11 @@ module Plist
   # can't be parsed into a Time object, please create an issue
   # attaching your plist file at https://github.com/patsplat/plist/issues
   # so folks can implement the proper support.
+  #
+  # By default, <data> will be assumed to be a marshaled Ruby object and
+  # interpreted with <tt>Marshal.load</tt>. Pass <tt>marshal: false</tt>
+  # to disable this behavior and return the raw binary data as an IO
+  # object instead.
   def self.parse_xml(filename_or_xml, options={})
     listener = Listener.new(options)
     # parser = REXML::Parsers::StreamParser.new(File.new(filename), listener)

--- a/lib/plist/parser.rb
+++ b/lib/plist/parser.rb
@@ -26,8 +26,8 @@ module Plist
   # can't be parsed into a Time object, please create an issue
   # attaching your plist file at https://github.com/patsplat/plist/issues
   # so folks can implement the proper support.
-  def self.parse_xml(filename_or_xml)
-    listener = Listener.new
+  def self.parse_xml(filename_or_xml, options={})
+    listener = Listener.new(options)
     # parser = REXML::Parsers::StreamParser.new(File.new(filename), listener)
     parser = StreamParser.new(filename_or_xml, listener)
     parser.parse
@@ -39,13 +39,14 @@ module Plist
 
     attr_accessor :result, :open
 
-    def initialize
+    def initialize(options={})
       @result = nil
       @open   = []
+      @options = { :marshal => true }.merge(options).freeze
     end
 
     def tag_start(name, attributes)
-      @open.push PTag.mappings[name].new
+      @open.push PTag.mappings[name].new(@options)
     end
 
     def text(contents)
@@ -154,9 +155,10 @@ module Plist
       mappings[key] = sub_class
     end
 
-    attr_accessor :text, :children
-    def initialize
+    attr_accessor :text, :children, :options
+    def initialize(options)
       @children = []
+      @options = options
     end
 
     def to_ruby
@@ -244,13 +246,13 @@ module Plist
     def to_ruby
       data = Base64.decode64(text.gsub(/\s+/, '')) unless text.nil?
       begin
-        return Marshal.load(data)
+        return Marshal.load(data) if options[:marshal]
       rescue Exception
-        io = StringIO.new
-        io.write data
-        io.rewind
-        return io
       end
+      io = StringIO.new
+      io.write data
+      io.rewind
+      io
     end
   end
 end


### PR DESCRIPTION
This allows `Marshal.load` to be turned off when parsing `<data>` elements, like this:

```ruby
Plist.parse_xml(filename_or_xml, marshal: false)
```

Addresses #58 