### PR TITLE
Remove runtime dependency on base64 gem to fix Ruby 3.3 warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,8 @@ else
   gem "rake", "~> 13.0"
 end
 
+if Gem::Requirement.new(">= 3.3").satisfied_by?(Gem::Version.new(RUBY_VERSION))
+  gem "base64"
+end
+
 gem "test-unit", "~> 3.5"

--- a/lib/plist.rb
+++ b/lib/plist.rb
@@ -9,7 +9,6 @@
 # Distributed under the MIT License
 #
 
-require 'base64'
 require 'cgi'
 require 'stringio'
 

--- a/lib/plist/generator.rb
+++ b/lib/plist/generator.rb
@@ -124,11 +124,9 @@ module Plist
 
       def data_tag(data, level)
         # note that apple plists are wrapped at a different length then
-        # what ruby's base64 wraps by default.
-        # I used #encode64 instead of #b64encode (which allows a length arg)
-        # because b64encode is b0rked and ignores the length arg.
+        # what ruby's pack wraps by default.
         tag('data', nil, level) do
-          Base64.encode64(data)
+          [data].pack("m")
                 .gsub(/\s+/, '')
                 .scan(/.{1,68}/o)
                 .collect { |line| indent(line, level) }

--- a/lib/plist/generator.rb
+++ b/lib/plist/generator.rb
@@ -126,7 +126,7 @@ module Plist
         # note that apple plists are wrapped at a different length then
         # what ruby's pack wraps by default.
         tag('data', nil, level) do
-          [data].pack("m")
+          [data].pack("m") # equivalent to Base64.encode64(data)
                 .gsub(/\s+/, '')
                 .scan(/.{1,68}/o)
                 .collect { |line| indent(line, level) }

--- a/lib/plist/parser.rb
+++ b/lib/plist/parser.rb
@@ -248,8 +248,8 @@ module Plist
 
   class PData < PTag
     def to_ruby
-      # unpack1("m") is equivalent to Base64.decode64
-      data = text.gsub(/\s+/, '').unpack1("m") unless text.nil?
+      # unpack("m")[0] is equivalent to Base64.decode64
+      data = text.gsub(/\s+/, '').unpack("m")[0] unless text.nil?
       begin
         return Marshal.load(data) if options[:marshal]
       rescue Exception

--- a/lib/plist/parser.rb
+++ b/lib/plist/parser.rb
@@ -248,6 +248,7 @@ module Plist
 
   class PData < PTag
     def to_ruby
+      # unpack1("m") is equivalent to Base64.decode64
       data = text.gsub(/\s+/, '').unpack1("m") unless text.nil?
       begin
         return Marshal.load(data) if options[:marshal]

--- a/lib/plist/parser.rb
+++ b/lib/plist/parser.rb
@@ -246,10 +246,9 @@ module Plist
     end
   end
 
-  require 'base64'
   class PData < PTag
     def to_ruby
-      data = Base64.decode64(text.gsub(/\s+/, '')) unless text.nil?
+      data = text.gsub(/\s+/, '').unpack1("m") unless text.nil?
       begin
         return Marshal.load(data) if options[:marshal]
       rescue Exception

--- a/plist.gemspec
+++ b/plist.gemspec
@@ -21,6 +21,4 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 1.9.3"
-
-  spec.add_dependency "base64"
 end

--- a/plist.gemspec
+++ b/plist.gemspec
@@ -21,4 +21,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 1.9.3"
+
+  spec.add_dependency "base64"
 end

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -1,4 +1,5 @@
 require 'test/unit'
+require 'base64'
 require 'plist'
 
 class TestParser < Test::Unit::TestCase


### PR DESCRIPTION
The base64 gem will no longer be included with Ruby starting in Ruby 3.4. Starting with Ruby 3.3, a warning is emitted.

The base64 gem is an extremely thin wrapper around `String#pack` and `String#unpack1`, so we can use those methods directly and omit the base64 dependency entirely.

I left base64 as a development dependency so that our unit tests can remain unchanged. This gives us confidence that no behavior has been changed as a result of this PR.

Fixes this warning:

> base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec.
