### PR TITLE
Fix frozen string literal warnings on Ruby 3.4

### DIFF
--- a/lib/plist/parser.rb
+++ b/lib/plist/parser.rb
@@ -56,7 +56,7 @@ module Plist
 
     def text(contents)
       if @open.last
-        @open.last.text ||= String.new
+        @open.last.text ||= ''.dup
         @open.last.text.concat(contents)
       end
     end

--- a/lib/plist/parser.rb
+++ b/lib/plist/parser.rb
@@ -56,7 +56,7 @@ module Plist
 
     def text(contents)
       if @open.last
-        @open.last.text ||= ''
+        @open.last.text ||= String.new
         @open.last.text.concat(contents)
       end
     end

--- a/test/test_data_elements.rb
+++ b/test/test_data_elements.rb
@@ -53,7 +53,7 @@ AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
 </data>
 END
 
-    expected.chomp!
+    expected = expected.chomp
 
     fd = IO.sysopen('test/assets/example_data.bin')
     io = IO.open(fd, 'r')


### PR DESCRIPTION
On the recently-released Ruby 3.4, the following warning is printed when using the `plist` gem:

> plist-3.7.1/lib/plist/parser.rb:60: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)

Fix by using `"".dup` to ensure the string literal is not frozen by default in future Ruby versions.