### PR TITLE
Pin test-unit gem to ensure CI works on Ruby 1.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,8 @@ if Gem::Requirement.new(">= 3.3").satisfied_by?(Gem::Version.new(RUBY_VERSION))
   gem "base64"
 end
 
-gem "test-unit", "~> 3.5"
+if Gem::Requirement.new("< 2.0").satisfied_by?(Gem::Version.new(RUBY_VERSION))
+  gem "test-unit", "~> 3.5.9"
+else
+  gem "test-unit", "~> 3.5"
+end


### PR DESCRIPTION
The `test-unit` gem recently added Ruby 2 keyword arguments to its implementation. This breaks our CI tests when running on Ruby 1.9, with errors like this:

```
/home/runner/work/plist/plist/vendor/bundle/ruby/1.9.1/gems/test-unit-3.6.7/lib/test/unit.rb:3:in `require':
/home/runner/work/plist/plist/vendor/bundle/ruby/1.9.1/gems/test-unit-3.6.7/lib/test/unit/testcase.rb:580:
syntax error, unexpected tLABEL (SyntaxError)
      def run(result, runner_class: nil)
                                   ^
```

Fix by pinning to an older version of the test-unit gem when running on Ruby 1.9.