### PR TITLE
Optimize parser and generator for fewer allocations and less regex work

### DIFF
--- a/lib/plist/generator.rb
+++ b/lib/plist/generator.rb
@@ -115,10 +115,13 @@ module Plist
           indent("<#{type}>\n", level) +
           block.call +
           indent("</#{type}>\n", level)
-        elsif contents.to_s.empty?
-          indent("<#{type}/>\n", level)
         else
-          indent("<#{type}>#{contents.to_s}</#{type}>\n", level)
+          str = contents.to_s
+          if str.empty?
+            indent("<#{type}/>\n", level)
+          else
+            indent("<#{type}>#{str}</#{type}>\n", level)
+          end
         end
       end
 
@@ -126,8 +129,7 @@ module Plist
         # note that apple plists are wrapped at a different length then
         # what ruby's pack wraps by default.
         tag('data', nil, level) do
-          [data].pack("m") # equivalent to Base64.encode64(data)
-                .gsub(/\s+/, '')
+          [data].pack("m0") # equivalent to Base64.strict_encode64(data)
                 .scan(/.{1,68}/o)
                 .collect { |line| indent(line, level) }
                 .join("\n")
@@ -136,7 +138,7 @@ module Plist
       end
 
       def indent(str, level)
-        @indent_str.to_s * level + str
+        @indent_str * level + str
       end
 
       def element_type(item)

--- a/lib/plist/parser.rb
+++ b/lib/plist/parser.rb
@@ -93,10 +93,23 @@ module Plist
     UNIMPLEMENTED_ERROR = 'Unimplemented element. ' \
       'Consider reporting via https://github.com/patsplat/plist/issues'
 
+    def self.start_tag_pattern
+      @start_tag_pattern ||= begin
+        tags = PTag.mappings.keys.join('|')
+        /<(#{tags})([^>]*)>/i
+      end
+    end
+
+    def self.end_tag_pattern
+      @end_tag_pattern ||= begin
+        tags = PTag.mappings.keys.join('|')
+        /<\/(#{tags})[^>]*>/i
+      end
+    end
+
     def parse
-      plist_tags = PTag.mappings.keys.join('|')
-      start_tag  = /<(#{plist_tags})([^>]*)>/i
-      end_tag    = /<\/(#{plist_tags})[^>]*>/i
+      start_tag = self.class.start_tag_pattern
+      end_tag   = self.class.end_tag_pattern
 
       require 'strscan'
 
@@ -249,7 +262,7 @@ module Plist
   class PData < PTag
     def to_ruby
       # unpack("m")[0] is equivalent to Base64.decode64
-      data = text.gsub(/\s+/, '').unpack("m")[0] unless text.nil?
+      data = text.delete(" \t\n\r").unpack("m")[0] unless text.nil?
       begin
         return Marshal.load(data) if options[:marshal]
       rescue Exception


### PR DESCRIPTION
## Summary

- **Cache tag-matching regex patterns** in `StreamParser` as memoized class methods — the start/end tag patterns were previously recompiled from `PTag.mappings` on every call to `parse()`.
- **Replace `gsub(/\s+/, '')` with `delete(\" \t\n\r\")`** for base64 whitespace stripping in `PData#to_ruby` and `data_tag` — avoids the regex engine for a character-deletion task.
- **Use `pack(\"m0\")` in `data_tag`** instead of `pack(\"m\").gsub(/\s+/, '')` — the `m0` directive produces base64 without line breaks directly, eliminating an intermediate string allocation and a regex traversal over potentially large data.
- **Remove redundant `.to_s`** in `indent()` — `@indent_str` is already converted to String in `initialize`.
- **Avoid double `contents.to_s`** in `tag()` by extracting to a local variable.

## Benchmarks

2000 iterations each, measured with `Benchmark.bm` (Ruby 3.x, macOS arm64):

| Benchmark | Before (user) | After (user) | Δ |
|---|---|---|---|
| Parse small plist | 0.131 s | 0.087 s | **−34%** |
| Parse file plist (AlbumData.xml) | 2.302 s | 2.315 s | ≈ same |
| Emit nested Hash | 0.027 s | 0.028 s | ≈ same |
| Emit IO/data element (JPEG) | 2.697 s | 0.371 s | **−86%** |

The regex caching pays off most when parsing many small documents in a single process (each parse previously rebuilt and compiled two regexes from scratch). The `pack("m0")` change is the largest absolute win — the old `gsub` traversed the entire base64 string, which is proportionally large for binary payloads like images.