### PR TITLE
Raise minimum version of ruby to avoid vulns

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        ruby: ["1.9", "2.0", "2.1", "2.2"]
+        ruby: ["2.2"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby

--- a/Gemfile
+++ b/Gemfile
@@ -1,18 +1,10 @@
 source "https://rubygems.org"
 gemspec
 
-if Gem::Requirement.new("< 2.2").satisfied_by?(Gem::Version.new(RUBY_VERSION))
-  gem "rake", "~> 11.3"
-else
-  gem "rake", "~> 13.0"
-end
+gem "rake", "~> 13.0"
 
 if Gem::Requirement.new(">= 3.3").satisfied_by?(Gem::Version.new(RUBY_VERSION))
   gem "base64"
 end
 
-if Gem::Requirement.new("< 2.0").satisfied_by?(Gem::Version.new(RUBY_VERSION))
-  gem "test-unit", "~> 3.5.9"
-else
-  gem "test-unit", "~> 3.5"
-end
+gem "test-unit", "~> 3.5"

--- a/plist.gemspec
+++ b/plist.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
   spec.files = %w{LICENSE.txt} + Dir.glob("lib/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 1.9.3"
+  spec.required_ruby_version = ">= 2.2"
 end


### PR DESCRIPTION
Should we drop support for Ruby < 2.2 to avoid [this vuln](https://github.com/patsplat/plist/security/dependabot/2)?

And if so, how should the version be bumped?